### PR TITLE
Improved plugins

### DIFF
--- a/ldurniat/berry.lua
+++ b/ldurniat/berry.lua
@@ -1272,7 +1272,7 @@ function Map:extend( ... )
 
     for i = 1, #objectTypes do 
 
-    	local extension = self.extensions or self.default_extensions
+    	local extension = self.default_extensions
 
       -- Load each module based on type
 		local plugin = require ( extension .. objectTypes[i] )

--- a/ldurniat/berry.lua
+++ b/ldurniat/berry.lua
@@ -1076,7 +1076,7 @@ function Map:new( filename, tilesets_dir, texturepacker_dir )
     map.tile_height   = data.tileheight
 
 	-- Add useful properties
-    map.default_extensions = 'berry.plugins.'
+    map.default_extensions = 'ldurniat.plugins.'
 
     -- TexturePacker directory will default to tilesets_dir if arg not present
     texturepacker_dir = texturepacker_dir or tilesets_dir
@@ -1268,17 +1268,17 @@ end
 --------------------------------------------------------------------------------
 function Map:extend( ... )
 	
-    local objectTypes = arg or {}
+    local object_types_list = arg or {}
 
-    for i = 1, #objectTypes do 
+    for _, object_type in ipairs( object_types_list ) do 
 
     	local extension = self.default_extensions
 
-      -- Load each module based on type
-		local plugin = require ( extension .. objectTypes[i] )
+		-- Load each module based on type
+		local plugin = require ( extension .. object_type )
 
 		-- Find each type of tiled object
-		local images = { self:getObjects( { type=objectTypes[i] } ) }
+		local images = { self:getObjects( { type=object_type } ) }
 
 		if images then 
 

--- a/ldurniat/berry.lua
+++ b/ldurniat/berry.lua
@@ -1268,9 +1268,9 @@ end
 --------------------------------------------------------------------------------
 function Map:extend( ... )
 	
-    local object_types_list = arg or {}
+    local list_of_types = arg or {}
 
-    for _, object_type in ipairs( object_types_list ) do 
+    for _, object_type in ipairs( list_of_types ) do 
 
     	local extension = self.default_extensions
 
@@ -1278,19 +1278,14 @@ function Map:extend( ... )
 		local plugin = require ( extension .. object_type )
 
 		-- Find each type of tiled object
-		local images = { self:getObjects( { type=object_type } ) }
+		local display_objects = { self:getObjects( { type=object_type } ) }
 
-		if images then 
+		for _, object in ipairs( display_objects ) do 
 
-			-- Do we have at least one?
-			for i = 1, #images do
-				
-				-- Extend the object with its own custom code
-				images[i] = plugin( images[i] )
+			-- Extend the object with its own custom code
+			object = plugin( object ) 
 
-			end
-
-		end  
+		end
 
     end
 

--- a/ldurniat/berry.lua
+++ b/ldurniat/berry.lua
@@ -1286,7 +1286,7 @@ function Map:extend( ... )
 			for i = 1, #images do
 				
 				-- Extend the object with its own custom code
-				images[i] = plugin.new( images[i] )
+				images[i] = plugin( images[i] )
 
 			end
 

--- a/ldurniat/plugins/label.lua
+++ b/ldurniat/plugins/label.lua
@@ -4,8 +4,6 @@
 
 -- Use this as a template to extend a tiled object with functionality
 
-local M = {}
-
 ------------------------------------------------------------------------------------------------
 -- Decoding color in hex format to ARGB.
 --
@@ -31,7 +29,7 @@ local function decodeTiledColor( hex )
 
 end
 
-function M.new( instance )
+function Plugin( instance )
 
   if not instance then error('ERROR: Expected display object') end  
   
@@ -87,4 +85,4 @@ function M.new( instance )
     
 end
 
-return M
+return Plugin

--- a/ldurniat/plugins/template.lua
+++ b/ldurniat/plugins/template.lua
@@ -1,0 +1,46 @@
+--------------------------------------------------------------------------------
+-- Default Plugin Template
+--
+-- Plugins allow a way to extend the functionality and properties of objects. 
+--
+-- All Tiled objects are Corona displayObjects and inherit their default methods
+-- and variables.  There are also Tiled objects that inherit from other groups 
+-- such as sprites (if animated), shapes, etc. 
+--------------------------------------------------------------------------------
+
+function Plugin( displayObject )
+
+  if not displayObject then error('ERROR: Expected display object') end  
+
+-- -----------------------------------
+-- SETUP NEW VARIABLES IF NEEDED
+-- -----------------------------------
+-- displayObject.foo = some_value
+-- displayObject.bar = other_value
+
+
+-- -----------------------------------
+-- CHANGE EXISTING VARIABLES IF NEEDED
+-- -----------------------------------
+-- displayObject.alpha = 1
+-- displayObject:scale(this_amount)
+-- displayObject:rotate(other_amount)
+
+
+-- -----------------------------------
+-- ADD NEW METHODS IF NEEDED
+-- -----------------------------------
+-- function displayObject:show()
+--   displayObject.alpha = 1
+-- end
+--
+-- function displayObject:hide()
+--   displayObject.alpha = 0
+-- end
+
+
+  return displayObject
+    
+end
+
+return Plugin


### PR DESCRIPTION
This removes a lot of the boiler plate code for plugins and makes it simpler.  There is also a template plugin file that users can consult as a reference.

Small changes were made to some existing variables and loops to improve readability and reduce code.  I did notice that the `map.extensions` is leftover code from the old version of berry.  I removed it for now, but later on you may want to bring it back and add a `plugins_dir` arg to maps so that users can choose where to put their plugins folder.