### PR TITLE
Add dynamic badges to README.md

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,21 +1,21 @@
-Lime - 2D Tile Engine for Corona SDK. (Original author: Graham Ranson)
-http://OutlawGameTools.com
-Copyright 2013 Three Ring Ranch
+MIT License
 
-The MIT License
+Copyright (c) 2013 Graham Ranson
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
-associated documentation files (the "Software"), to deal in the Software without restriction, 
-including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, 
-subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial 
-portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT 
-NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND 
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES 
-OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+![Tiled Image](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQwQuIoJbpLomvzgVmEvoXyQ5B7kPrZmtT1WuEs6xX-NxBxcGL3KQ)
+![Texturepacker Image](https://www.codeandweb.com/o/img/texturepacker512-512.png)
+
 [![GitHub contributors](https://img.shields.io/github/contributors/ldurniat/berry.svg)](https://github.com/ldurniat/Berry/graphs/contributors)
 [![GitHub last commit](https://img.shields.io/github/last-commit/ldurniat/berry.svg)](https://github.com/ldurniat/Berry/commits/master)
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/ldurniat/berry.svg)](https://github.com/ldurniat/Berry/pulls)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 ![Tiled Image](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQwQuIoJbpLomvzgVmEvoXyQ5B7kPrZmtT1WuEs6xX-NxBxcGL3KQ)
 ![Texturepacker Image](https://www.codeandweb.com/o/img/texturepacker512-512.png)
 
+[![Tiled version](https://img.shields.io/badge/Tiled-v1.2.0-blue.svg)](https://www.mapeditor.org/)
+[![Texturepacker version](https://img.shields.io/badge/TexturePacker-v3.4.0-blue.svg)](https://www.codeandweb.com/texturepacker)
+[![Corona version](https://img.shields.io/badge/Corona-v2018.3326-blue.svg)](https://coronalabs.com/)
 [![GitHub contributors](https://img.shields.io/github/contributors/ldurniat/berry.svg)](https://github.com/ldurniat/Berry/graphs/contributors)
 [![GitHub last commit](https://img.shields.io/github/last-commit/ldurniat/berry.svg)](https://github.com/ldurniat/Berry/commits/master)
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/ldurniat/berry.svg)](https://github.com/ldurniat/Berry/pulls)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+[![GitHub contributors](https://img.shields.io/github/contributors/ldurniat/berry.svg)](https://github.com/ldurniat/Berry/graphs/contributors)
+[![GitHub last commit](https://img.shields.io/github/last-commit/ldurniat/berry.svg)](https://github.com/ldurniat/Berry/commits/master)
+[![GitHub pull requests](https://img.shields.io/github/issues-pr/ldurniat/berry.svg)](https://github.com/ldurniat/Berry/pulls)
+[![GitHub issues](https://img.shields.io/github/issues/ldurniat/berry.svg)](https://github.com/ldurniat/Berry/issues)
+[![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/ldurniat/berry.svg)](http://isitmaintained.com/project/ldurniat/berry "Average time to resolve an issue")
+[![GitHub](https://img.shields.io/github/license/ldurniat/berry.svg)](https://choosealicense.com/licenses/mit/)
+
 # Berry
 *Berry* is a simple [Tiled Map](www.mapeditor.org) loader for Corona SDK.  Berry is also able to load and use TexturePacker sprites inside a Tiled map.
 


### PR DESCRIPTION
This PR does several cosmetic things.  It adds several helpful badges to the `README.md` to display the state of the project.  Each of these badges can be clicked and lead to various locations for the repo.  One thing that I did need to change was to make a _slight_ change to the license.  This was only done so that Github can recognize the license properly and allow the badge to display correctly.

To see more information on badges I’d refer you to this - https://github.com/badges/shields