### PR TITLE
Texturepack Bugfix

### DIFF
--- a/ldurniat/berry.lua
+++ b/ldurniat/berry.lua
@@ -1347,7 +1347,7 @@ end
 --------------------------------------------------------------------------------
 function Map:addSprite( layer, image_name, x, y )
 
-	layer = map:getLayer( layer )
+	layer = self:getLayer( layer )
 
 	local object = {
 		texture = image_name,

--- a/ldurniat/plugins/template.lua
+++ b/ldurniat/plugins/template.lua
@@ -8,10 +8,7 @@
 -- such as sprites (if animated), shapes, etc. 
 --------------------------------------------------------------------------------
 
-function Plugin( displayObject )
-
-  if not displayObject then error('ERROR: Expected display object') end  
-
+function Plugin( displayObject ) 
 -- -----------------------------------
 -- SETUP NEW VARIABLES IF NEEDED
 -- -----------------------------------
@@ -31,13 +28,12 @@ function Plugin( displayObject )
 -- ADD NEW METHODS IF NEEDED
 -- -----------------------------------
 -- function displayObject:show()
---   displayObject.alpha = 1
+--   displayObject.isVisible = true
 -- end
 --
 -- function displayObject:hide()
---   displayObject.alpha = 0
+--   displayObject.isVisible = false
 -- end
-
 
   return displayObject
     


### PR DESCRIPTION
This PR fixes a bug when texturepack sprites are inserted into the map that was causing a crash.  Also made some slight tweaks to the plugin template.